### PR TITLE
ベースイメージをnode16に変更する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.16.3-buster-slim
+FROM --platform=linux/amd64 node:16.19.1-buster-slim
 
 LABEL maintainer="Piotr Antczak <antczak.piotr@gmail.com>"
 WORKDIR /clamav-rest-api

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,18 +1,19 @@
 version: '3.8'
 services:
   clamd:
-    image: clamav/clamav:0.104
+    image: clamav/clamav:1.0.1
     restart: unless-stopped
     networks:
       - clam-net
   api:
-    image: benzino77/clamav-rest-api
+    build: ../
+    image: clamav-rest-api
     restart: unless-stopped
     # depends_on is ignored in some situations (have a look at the discussion in this PR: https://github.com/benzino77/clamav-rest-api/pull/23)
     # to fix such situation there is wait-for-it script available inside the CRA docker image (https://github.com/vishnubob/wait-for-it)
     # so to wait for clamd to be available, one could ovewrite the CMD with wait-for-it script
     # UNCOMMENT following line to check if clamav is available on host clamd and port 3310, set timeout to 60 seconds
-    # command: ['/usr/bin/wait-for-it', '-h', 'clamd', '-p', '3310', '-s', '-t', '60', '--', 'npm', 'start']
+    command: ['/usr/bin/wait-for-it', '-h', 'clamd', '-p', '3310', '-s', '-t', '60', '--', 'npm', 'start']
     depends_on:
       - clamd
     environment:
@@ -20,6 +21,7 @@ services:
       - CLAMD_IP=clamd
       - APP_FORM_KEY=FILES
       - APP_PORT=3000
+      - APP_MAX_FILE_SIZE=6291456 # 6MiB
     ports:
       - '8080:3000'
     networks:

--- a/examples/test/docker-compose.yml
+++ b/examples/test/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.8'
+services:
+  api:
+    build: ../../
+    image: clamav-rest-api
+    restart: 'no'
+    # depends_on is ignored in some situations (have a look at the discussion in this PR: https://github.com/benzino77/clamav-rest-api/pull/23)
+    # to fix such situation there is wait-for-it script available inside the CRA docker image (https://github.com/vishnubob/wait-for-it)
+    # so to wait for clamd to be available, one could ovewrite the CMD with wait-for-it script
+    # UNCOMMENT following line to check if clamav is available on host clamd and port 3310, set timeout to 60 seconds
+    command: ['npm', 'test']
+    environment:
+      - NODE_ENV=test
+      - CLAMD_IP=clamd
+      - APP_FORM_KEY=FILES
+      - APP_PORT=3000
+      - APP_MAX_FILE_SIZE=2097152
+      - APP_MAX_FILES_NUMBER=2
+    ports:
+      - '8080:3000'


### PR DESCRIPTION
## 課題

- ベースイメージが古い
- Node.js v12はサポートが終了している

## 対応

- ベースイメージをNode.js v16の最新版に変更しました。
- docker-compose.ymlをベースイメージ変更後のコンテナイメージで起動するように修正しました。
- 単体テスト実行用のdocker-compose.ymlを追加しました。